### PR TITLE
Unify homepage work list; fix heading structure; add starred-dot marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Every page extends the base layout and fills in a `content` block:
 {% block content %}
   {# Your page HTML goes here — plain HTML, no special syntax required #}
   <div class="section">
-    <h3 class="section--title">Hello</h3>
+    <h2 class="section--title">Hello</h2>
     <div class="section--content">
       <p>This is normal HTML.</p>
     </div>
@@ -137,12 +137,12 @@ Wraps content in `.section` / `.section--content`. Uses `{% call %}` because the
 ```njk
 {% from "components/_section.njk" import section %}
 
-{# Standard section (h3) #}
+{# Standard section (h2) #}
 {% call section("Research & Discovery") %}
   <p>Section content here.</p>
 {% endcall %}
 
-{# Project title section (h2 + hero styling) — first section on a project page only #}
+{# Project title section (h1 + hero styling) — first section on a project page only #}
 {% call section("Project Name", isTitle=true) %}
   <p>Project intro paragraph.</p>
 {% endcall %}
@@ -232,4 +232,19 @@ Step numbers and arrow connectors are generated automatically. The `body` field 
 {# Custom message and icon (uses Material Icons names) #}
 {{ bannerAlert("Coming soon.", "schedule") }}
 ```
+
+---
+
+#### `workItem` — a row in the homepage work list
+
+```njk
+{% from "components/_work-item.njk" import workItem %}
+
+{{ workItem("./work/cloudflare-appsec-overview.html", "AppSec Overview", "Cloudflare", "2024-2025") }}
+
+{# starred — solid, slowly-pulsing dot marking standout work #}
+{{ workItem("./work/tactile-toolkit.html", "Tactile Toolkit", "IBM", "2019", starred=true) }}
+```
+
+All rows render at the same weight; `starred` only controls the dot. To flag (or unflag) a project later without touching the macro call, just add or remove the `work-item--starred` class directly on its `<li>` in `src/index.njk`.
 

--- a/index.html
+++ b/index.html
@@ -54,115 +54,83 @@
 
         
         <div class="home-work" id="work">
-            <p class="home-work__heading">Favorites</p>
+            <h2 class="home-work__heading">Work</h2>
             <ul class="home-work__list">
-                <li class="work-item work-item--featured">
+                <li class="work-item work-item--starred">
     <a href="./work/cloudflare-appsec-overview.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">AppSec Overview</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">Application Security Overview</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">Cloudflare</span>
         <span class="work-item__year">2024-2025</span>
-    </a>
+<span class="sr-only">Featured project</span>    </a>
 </li>
 
-                <li class="work-item work-item--featured">
-    <a href="./work/blog-graphics.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">Blog Banners &amp; Diagrams</span>
-        <span class="work-item__company">Cloudflare</span>
-        <span class="work-item__year">2022-2023</span>
-    </a>
-</li>
-
-                <li class="work-item work-item--featured">
-    <a href="./work/vpc.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">IBM Cloud VPC</span>
-        <span class="work-item__company">IBM</span>
-        <span class="work-item__year">2020</span>
-    </a>
-</li>
-
-                <li class="work-item work-item--featured">
-    <a href="./work/tactile-toolkit.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">Tactile Toolkit</span>
-        <span class="work-item__company">IBM</span>
-        <span class="work-item__year">2019</span>
-    </a>
-</li>
-
-            </ul>
-        </div>
-
-        
-        <div class="home-work home-work--secondary-list">
-            <p class="home-work__heading">Selected Work</p>
-            <ul class="home-work__list">
-                
-                <li class="work-item work-item--featured">
-    <a href="./work/cloudflare-appsec-overview.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">AppSec Overview</span>
-        <span class="work-item__company">Cloudflare</span>
-        <span class="work-item__year">2024-2025</span>
-    </a>
-</li>
-
-                <li class="work-item work-item--featured">
+                <li class="work-item">
     <a href="./work/cloudflare-email-routing.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">Email Routing</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">Email Routing</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">Cloudflare</span>
         <span class="work-item__year">2023</span>
     </a>
 </li>
 
-                <li class="work-item work-item--featured">
+                <li class="work-item work-item--starred">
     <a href="./work/blog-graphics.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">Blog Banners &amp; Diagrams</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">Blog Banners &amp; Diagrams</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">Cloudflare</span>
         <span class="work-item__year">2022-2023</span>
-    </a>
+<span class="sr-only">Featured project</span>    </a>
 </li>
 
-
-                
-                <li class="work-item work-item--secondary">
+                <li class="work-item">
     <a href="./work/cloudflare-workers-unbound.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">Workers Unbound</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">Workers Unbound</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">Cloudflare</span>
         <span class="work-item__year">2022</span>
     </a>
 </li>
 
-                <li class="work-item work-item--secondary">
+                <li class="work-item">
     <a href="./work/cis.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">IBM Cloud Internet Services</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">IBM Cloud Internet Services</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">IBM</span>
         <span class="work-item__year">2021</span>
     </a>
 </li>
 
-                <li class="work-item work-item--secondary">
+                <li class="work-item work-item--starred">
     <a href="./work/vpc.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">IBM Cloud VPC</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">IBM Cloud VPC</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">IBM</span>
         <span class="work-item__year">2020</span>
-    </a>
+<span class="sr-only">Featured project</span>    </a>
 </li>
 
-                <li class="work-item work-item--secondary">
+                <li class="work-item work-item--starred">
     <a href="./work/tactile-toolkit.html">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">Tactile Toolkit</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">Tactile Toolkit</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">IBM</span>
         <span class="work-item__year">2019</span>
-    </a>
+<span class="sr-only">Featured project</span>    </a>
 </li>
 
             </ul>
@@ -170,11 +138,11 @@
 
         
         <div class="home-other-work">
-            <p class="home-work__heading">Other Cloudflare Work</p>
+            <h2 class="home-work__heading">Other Cloudflare Work</h2>
             <p class="home-other-work__intro">Projects I shipped at Cloudflare that don&rsquo;t have full case studies &mdash; each links to the launch blog post.</p>
 
             <div class="home-other-work__group">
-                <p class="home-other-work__label">// API Shield</p>
+                <h3 class="home-other-work__label">// API Shield</h3>
                 <ul class="home-other-work__list">
                     <li><a href="https://blog.cloudflare.com/protecting-apis-from-abuse-using-sequence-learning-and-variable-order-markov/" target="_blank" rel="noopener">Block malicious API request sequences at the edge</a></li>
                     <li><a href="https://blog.cloudflare.com/ml-api-discovery-and-schema-learning/" target="_blank" rel="noopener">API Schema Learning and endpoint discovery</a></li>
@@ -188,7 +156,7 @@
             </div>
 
             <div class="home-other-work__group">
-                <p class="home-other-work__label">// Bots &amp; AI</p>
+                <h3 class="home-other-work__label">// Bots &amp; AI</h3>
                 <ul class="home-other-work__list">
                     <li><a href="https://blog.cloudflare.com/ai-audit-enforcing-robots-txt/" target="_blank" rel="noopener">Block AI bots: robots.txt enforcement</a></li>
                     <li><a href="https://blog.cloudflare.com/declaring-your-aindependence-block-ai-bots-scrapers-and-crawlers-with-a-single-click/" target="_blank" rel="noopener">Block AI bots with one click</a></li>
@@ -200,7 +168,7 @@
 
         
         <div class="home-recognition">
-            <p class="home-work__heading">Recognition</p>
+            <h2 class="home-work__heading">Recognition</h2>
             <ul class="home-recognition__list">
 
                 <li class="home-recognition__item">
@@ -222,7 +190,7 @@
 
         
         <div class="home-testimonials">
-            <p class="home-work__heading">// Kind Words</p>
+            <h2 class="home-work__heading">// Kind Words</h2>
 
             <div class="testimonials-carousel" id="testimonialsCarousel">
                 <div class="testimonials-track" id="testimonialsTrack">

--- a/scss/_home.scss
+++ b/scss/_home.scss
@@ -265,11 +265,6 @@ $bp-home-mobile: 768px;
         margin: 0 0 0;
     }
 
-    // Second list section gets extra top breathing room
-    &--secondary-list {
-        margin-top: 36px;
-    }
-
     &__list {
         list-style: none;
         margin: 0;
@@ -304,16 +299,19 @@ $bp-home-mobile: 768px;
         color: var(--text-primary) !important;
     }
 
-    &:hover .work-item__dot {
-        background: var(--accent) !important;
-    }
-
     &:hover .work-item__year {
         color: var(--text-muted) !important;
     }
 
+    // Grid on desktop so company lines up in its own fixed column across every
+    // row, regardless of title length — [title+dot] | company | year. Title
+    // gets a generous fixed track (widest current title is ~30 characters) plus
+    // an ellipsis fallback so a future longer one degrades instead of breaking
+    // the column. Mobile reverts to the simpler flex-packed row — not enough
+    // width for fixed columns to read as a benefit there.
     a {
-        display: flex;
+        display: grid;
+        grid-template-columns: 320px 110px 1fr;
         align-items: center;
         gap: 14px;
         padding: 18px 0;
@@ -321,17 +319,34 @@ $bp-home-mobile: 768px;
         border-bottom: 0.5px solid var(--work-row-border);
 
         @media (max-width: $bp-home-mobile) {
+            display: flex;
             gap: 10px;
             padding: 12px 0;
         }
     }
 
+    // Title + dot travel together as one unit, so the dot always sits a fixed
+    // 16px from the title text itself — not from the edge of the (fixed-width)
+    // title column, which is what made it read as floating/disconnected on
+    // shorter titles.
+    &__title-group {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        width: 100%;   // fill the fixed 320px grid column so company still aligns
+        min-width: 0;  // lets the title ellipsis truncate inside a flex child
+    }
+
+    // Empty/transparent by default — only .work-item--starred fills it in,
+    // so every row still lines up on the same column whether starred or not.
     &__dot {
+        position: relative; // anchors the pulse ring on starred rows
         width: 5px;
         height: 5px;
+        border-radius: 50%;
         flex-shrink: 0;
         display: block;
-        transition: background 0.2s;
+        background: transparent;
 
         @media (max-width: $bp-home-mobile) {
             width: 4px;
@@ -343,16 +358,23 @@ $bp-home-mobile: 768px;
         font-size: 20px;   // md
         font-weight: 400;
         font-family: "Chakra Petch", sans-serif;
+        color: var(--work-title);
         transition: color 0.15s;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0; // flex children default to min-width:auto, which blocks ellipsis
 
         @media (max-width: $bp-home-mobile) {
             font-size: 16px;   // base on mobile
+            white-space: normal; // fixed-width column is desktop-only; let it wrap on mobile
         }
     }
 
     &__company {
         font-size: 13px;   // sm
         font-family: "IBM Plex Mono", monospace;
+        color: var(--work-company);
         margin-left: 2px;
         transition: color 0.15s;
     }
@@ -360,25 +382,49 @@ $bp-home-mobile: 768px;
     &__year {
         font-size: 13px;   // sm
         font-family: "IBM Plex Mono", monospace;
+        color: var(--work-year);
         margin-left: auto;
         flex-shrink: 0;
         transition: color 0.15s;
     }
 
-    // Featured — top projects, full brightness
-    &--featured {
-        .work-item__dot     { background: var(--work-dot-featured); }
-        .work-item__title   { color: var(--work-title-featured); }
-        .work-item__company { color: var(--work-company-featured); }
-        .work-item__year    { color: var(--work-year-featured); }
-    }
+    // Standout projects — solid, slowly-pulsing dot. To flag one by hand,
+    // just add this class to its <li> — no other markup changes needed.
+    &--starred {
+        .work-item__dot {
+            background: var(--work-dot-starred);
 
-    // Secondary — older or lower-priority, dimmed
-    &--secondary {
-        .work-item__dot     { background: var(--work-dot-secondary); }
-        .work-item__title   { color: var(--work-title-secondary); }
-        .work-item__company { color: var(--work-company-secondary); }
-        .work-item__year    { color: var(--work-year-secondary); }
+            // Ring expands outward from the dot and fades, on a slow loop.
+            &::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 100%;
+                height: 100%;
+                border-radius: 50%;
+                border: 1px solid var(--work-dot-starred);
+                transform: translate(-50%, -50%) scale(1);
+                animation: work-dot-pulse 3s ease-out infinite;
+                pointer-events: none;
+
+                @media (prefers-reduced-motion: reduce) {
+                    animation: none;
+                    opacity: 0;
+                }
+            }
+        }
+    }
+}
+
+@keyframes work-dot-pulse {
+    0% {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 0.55;
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(2.4);
+        opacity: 0;
     }
 }
 
@@ -458,7 +504,7 @@ $bp-home-mobile: 768px;
         display: block;
         font-size: 20px;   // md
         font-weight: 500;
-        color: var(--work-title-featured);
+        color: var(--work-title);
         margin-bottom: 8px;
 
         @media (max-width: $bp-home-mobile) {

--- a/scss/_tokens.scss
+++ b/scss/_tokens.scss
@@ -33,18 +33,12 @@
     --border:          rgba(255, 255, 255, 0.10);
     --strip-border:    rgba(255, 255, 255, 0.08);
 
-    // Work list — featured (top, full brightness)
-    --work-dot-featured:    #3e8ef4; // matches --accent
-    --work-title-featured:  rgba(255, 255, 255, 0.95);
-    --work-company-featured:rgba(255, 255, 255, 0.50);
-    --work-year-featured:   rgba(255, 255, 255, 0.60);
-
-    // Work list — secondary (dimmed but still readable without effort)
-    // Company/year floor is rgba(255,255,255,0.45) minimum — never lower contrast than this.
-    --work-dot-secondary:    rgba(62, 142, 244, 0.45); // --work-dot-featured at reduced opacity
-    --work-title-secondary:  rgba(255, 255, 255, 0.62);
-    --work-company-secondary:rgba(255, 255, 255, 0.45);
-    --work-year-secondary:   rgba(255, 255, 255, 0.48);
+    // Work list — every row renders at the same weight; only the starred
+    // marker (dot) distinguishes standout projects. See _home.scss.
+    --work-title:   rgba(255, 255, 255, 0.95);
+    --work-company: rgba(255, 255, 255, 0.50);
+    --work-year:    rgba(255, 255, 255, 0.60);
+    --work-dot-starred: #3e8ef4; // matches --accent
 
     // Work row
     --work-row-border: rgba(255, 255, 255, 0.08);
@@ -70,18 +64,11 @@
         --border:          rgba(0, 0, 0, 0.08);
         --strip-border:    rgba(0, 0, 0, 0.07);
 
-        // Work list — featured
-        --work-dot-featured:    #08428c; // matches --accent-text
-        --work-title-featured:  #07090f;
-        --work-company-featured:#888888;
-        --work-year-featured:   #888888;
-
-        // Work list — secondary
-        // Title is the row's link label (4.5:1 min); company/year floor is #888 — never lower contrast than this.
-        --work-dot-secondary:    rgba(8, 66, 140, 0.5); // --work-dot-featured at reduced opacity
-        --work-title-secondary:  #767676;
-        --work-company-secondary:#888888;
-        --work-year-secondary:   #888888;
+        // Work list
+        --work-title:   #07090f;
+        --work-company: #888888;
+        --work-year:    #888888;
+        --work-dot-starred: #08428c; // matches --accent-text
 
         // Work row
         --work-row-border: rgba(0, 0, 0, 0.07);

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -17,6 +17,19 @@ html, body {
     background-color: var(--bg, #fafafb); // homepage uses --bg; project pages inherit old value
 }
 
+// Visually hidden but still announced by screen readers.
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 h1, h2 {
     margin: 0;
 }

--- a/src/components/_work-item.njk
+++ b/src/components/_work-item.njk
@@ -1,30 +1,35 @@
 {#
   _work-item.njk
   --------------
-  A single row in the homepage work lists (Favorites / Selected Work).
-  Renders the <li> with the dot, title, company, and year, plus the
-  featured/secondary modifier that controls brightness.
+  A single row in the homepage work list. Renders the <li> with the dot,
+  title, company, and year. All rows render at the same weight — `starred`
+  only controls whether the dot shows as a solid, slowly-pulsing marker.
 
   Usage:
     {% from "components/_work-item.njk" import workItem %}
-    {{ workItem("./work/cloudflare-appsec-overview.html", "AppSec Overview", "Cloudflare", "2024") }}
-    {{ workItem("./work/cis.html", "IBM Cloud Internet Services", "IBM", "2021", featured=false) }}
+    {{ workItem("./work/cloudflare-appsec-overview.html", "Application Security Overview", "Cloudflare", "2024") }}
+    {{ workItem("./work/tactile-toolkit.html", "Tactile Toolkit", "IBM", "2019", starred=true) }}
 
   Parameters:
     href      — link to the project case study page (required)
     title     — project name (required). May contain inline HTML entities.
     company   — company label shown after the title (required)
     year      — year label, right-aligned (required)
-    featured  — true → full-brightness "--featured"; false → dimmed "--secondary".
-                Default: true
+    starred   — true → shows a solid, pulsing dot marking this as standout work.
+                Default: false. To flag a project by hand later, add the
+                `work-item--starred` class directly to its <li> — no macro
+                change needed.
 #}
-{% macro workItem(href, title, company, year, featured=true) %}
-<li class="work-item work-item--{{ "featured" if featured else "secondary" }}">
+{% macro workItem(href, title, company, year, starred=false) %}
+<li class="work-item{{ ' work-item--starred' if starred }}">
     <a href="{{ href }}">
-        <span class="work-item__dot"></span>
-        <span class="work-item__title">{{ title }}</span>
+        <span class="work-item__title-group">
+            <span class="work-item__title">{{ title }}</span>
+            <span class="work-item__dot"></span>
+        </span>
         <span class="work-item__company">{{ company }}</span>
         <span class="work-item__year">{{ year }}</span>
+        {% if starred %}<span class="sr-only">Featured project</span>{% endif %}
     </a>
 </li>
 {% endmacro %}

--- a/src/index.njk
+++ b/src/index.njk
@@ -47,41 +47,27 @@
             <p class="home-bio">Senior product designer who designs and codes using AI-assisted workflows to take complex, ambiguous problems from concept to product. I'm looking for my next thing, so say hi: <a href="mailto:design@sraden.com">design@sraden.com</a>.</p>
         </div>
 
-        {# ── Case Studies — priority pieces with substantial written work ── #}
+        {# ── Work — single chronological list; starred = standout projects ── #}
         <div class="home-work" id="work">
-            <p class="home-work__heading">Favorites</p>
+            <h2 class="home-work__heading">Work</h2>
             <ul class="home-work__list">
-                {{ workItem("./work/cloudflare-appsec-overview.html", "AppSec Overview", "Cloudflare", "2024-2025") }}
-                {{ workItem("./work/blog-graphics.html", "Blog Banners &amp; Diagrams", "Cloudflare", "2022-2023") }}
-                {{ workItem("./work/vpc.html", "IBM Cloud VPC", "IBM", "2020") }}
-                {{ workItem("./work/tactile-toolkit.html", "Tactile Toolkit", "IBM", "2019") }}
-            </ul>
-        </div>
-
-        {# ── Selected Work — full project list ─────────────────────────── #}
-        <div class="home-work home-work--secondary-list">
-            <p class="home-work__heading">Selected Work</p>
-            <ul class="home-work__list">
-                {# Featured — strongest / most recent #}
-                {{ workItem("./work/cloudflare-appsec-overview.html", "AppSec Overview", "Cloudflare", "2024-2025") }}
+                {{ workItem("./work/cloudflare-appsec-overview.html", "Application Security Overview", "Cloudflare", "2024-2025", starred=true) }}
                 {{ workItem("./work/cloudflare-email-routing.html", "Email Routing", "Cloudflare", "2023") }}
-                {{ workItem("./work/blog-graphics.html", "Blog Banners &amp; Diagrams", "Cloudflare", "2022-2023") }}
-
-                {# Secondary — solid work but lower priority in the list #}
-                {{ workItem("./work/cloudflare-workers-unbound.html", "Workers Unbound", "Cloudflare", "2022", featured=false) }}
-                {{ workItem("./work/cis.html", "IBM Cloud Internet Services", "IBM", "2021", featured=false) }}
-                {{ workItem("./work/vpc.html", "IBM Cloud VPC", "IBM", "2020", featured=false) }}
-                {{ workItem("./work/tactile-toolkit.html", "Tactile Toolkit", "IBM", "2019", featured=false) }}
+                {{ workItem("./work/blog-graphics.html", "Blog Banners &amp; Diagrams", "Cloudflare", "2022-2023", starred=true) }}
+                {{ workItem("./work/cloudflare-workers-unbound.html", "Workers Unbound", "Cloudflare", "2022") }}
+                {{ workItem("./work/cis.html", "IBM Cloud Internet Services", "IBM", "2021") }}
+                {{ workItem("./work/vpc.html", "IBM Cloud VPC", "IBM", "2020", starred=true) }}
+                {{ workItem("./work/tactile-toolkit.html", "Tactile Toolkit", "IBM", "2019", starred=true) }}
             </ul>
         </div>
 
         {# ── Other Cloudflare Work ─────────────────────────────────────── #}
         <div class="home-other-work">
-            <p class="home-work__heading">Other Cloudflare Work</p>
+            <h2 class="home-work__heading">Other Cloudflare Work</h2>
             <p class="home-other-work__intro">Projects I shipped at Cloudflare that don&rsquo;t have full case studies &mdash; each links to the launch blog post.</p>
 
             <div class="home-other-work__group">
-                <p class="home-other-work__label">// API Shield</p>
+                <h3 class="home-other-work__label">// API Shield</h3>
                 <ul class="home-other-work__list">
                     <li><a href="https://blog.cloudflare.com/protecting-apis-from-abuse-using-sequence-learning-and-variable-order-markov/" target="_blank" rel="noopener">Block malicious API request sequences at the edge</a></li>
                     <li><a href="https://blog.cloudflare.com/ml-api-discovery-and-schema-learning/" target="_blank" rel="noopener">API Schema Learning and endpoint discovery</a></li>
@@ -95,7 +81,7 @@
             </div>
 
             <div class="home-other-work__group">
-                <p class="home-other-work__label">// Bots &amp; AI</p>
+                <h3 class="home-other-work__label">// Bots &amp; AI</h3>
                 <ul class="home-other-work__list">
                     <li><a href="https://blog.cloudflare.com/ai-audit-enforcing-robots-txt/" target="_blank" rel="noopener">Block AI bots: robots.txt enforcement</a></li>
                     <li><a href="https://blog.cloudflare.com/declaring-your-aindependence-block-ai-bots-scrapers-and-crawlers-with-a-single-click/" target="_blank" rel="noopener">Block AI bots with one click</a></li>
@@ -107,7 +93,7 @@
 
         {# ── Recognition ───────────────────────────────────────────────── #}
         <div class="home-recognition">
-            <p class="home-work__heading">Recognition</p>
+            <h2 class="home-work__heading">Recognition</h2>
             <ul class="home-recognition__list">
 
                 <li class="home-recognition__item">
@@ -129,7 +115,7 @@
 
         {# ── Testimonials carousel ─────────────────────────────────────────── #}
         <div class="home-testimonials">
-            <p class="home-work__heading">// Kind Words</p>
+            <h2 class="home-work__heading">// Kind Words</h2>
 
             <div class="testimonials-carousel" id="testimonialsCarousel">
                 <div class="testimonials-track" id="testimonialsTrack">

--- a/src/work/cloudflare-appsec-overview.njk
+++ b/src/work/cloudflare-appsec-overview.njk
@@ -5,11 +5,11 @@
 
 {% set projectSymbol = "✦" %}
 
-{% set title = "AppSec Overview" %}
+{% set title = "Application Security Overview" %}
 
 {% block content %}
 
-{% call section("AppSec Overview", isTitle=true) %}
+{% call section("Application Security Overview", isTitle=true) %}
     <p>
         Cloudflare has a suite of application security products including WAF, Bot Management, API Shield, DDoS Protection, and more. Each lived in its own corner of the dashboard. Customers had no shared starting point. Nowhere to land, see their security posture, and understand what actually needed their attention.
     </p>

--- a/src/work/vuln-scanner-9f3de1.njk
+++ b/src/work/vuln-scanner-9f3de1.njk
@@ -100,7 +100,7 @@
         },
         {
             title: "Review results",
-            body: "Results appear at two levels: high-level discoveries (patterns across endpoints) and per-step test detail (exact requests, credentials used, expected vs. received response codes). Completed scan findings are also routed to the <a href=\"./cloudflare-appsec-overview.html\">AppSec Overview</a> as Security Posture action items, putting them at the customer&rsquo;s AppSec entry point rather than requiring navigation to a separate tool."
+            body: "Results appear at two levels: high-level discoveries (patterns across endpoints) and per-step test detail (exact requests, credentials used, expected vs. received response codes). Completed scan findings are also routed to the <a href=\"./cloudflare-appsec-overview.html\">Application Security Overview</a> as Security Posture action items, putting them at the customer&rsquo;s AppSec entry point rather than requiring navigation to a separate tool."
         },
         {
             title: "Verify and fix",

--- a/style/main.css
+++ b/style/main.css
@@ -15,14 +15,10 @@
   --text-muted: rgba(255, 255, 255, 0.56);
   --border: rgba(255, 255, 255, 0.10);
   --strip-border: rgba(255, 255, 255, 0.08);
-  --work-dot-featured: #3e8ef4;
-  --work-title-featured: rgba(255, 255, 255, 0.95);
-  --work-company-featured:rgba(255, 255, 255, 0.50);
-  --work-year-featured: rgba(255, 255, 255, 0.60);
-  --work-dot-secondary: rgba(62, 142, 244, 0.45);
-  --work-title-secondary: rgba(255, 255, 255, 0.62);
-  --work-company-secondary:rgba(255, 255, 255, 0.45);
-  --work-year-secondary: rgba(255, 255, 255, 0.48);
+  --work-title: rgba(255, 255, 255, 0.95);
+  --work-company: rgba(255, 255, 255, 0.50);
+  --work-year: rgba(255, 255, 255, 0.60);
+  --work-dot-starred: #3e8ef4;
   --work-row-border: rgba(255, 255, 255, 0.08);
   --strip-dot: rgba(255, 255, 255, 0.22);
   --strip-cross: rgba(255, 255, 255, 0.20);
@@ -38,14 +34,10 @@
     --text-muted: #888888;
     --border: rgba(0, 0, 0, 0.08);
     --strip-border: rgba(0, 0, 0, 0.07);
-    --work-dot-featured: #08428c;
-    --work-title-featured: #07090f;
-    --work-company-featured:#888888;
-    --work-year-featured: #888888;
-    --work-dot-secondary: rgba(8, 66, 140, 0.5);
-    --work-title-secondary: #767676;
-    --work-company-secondary:#888888;
-    --work-year-secondary: #888888;
+    --work-title: #07090f;
+    --work-company: #888888;
+    --work-year: #888888;
+    --work-dot-starred: #08428c;
     --work-row-border: rgba(0, 0, 0, 0.07);
     --strip-dot: rgba(0, 0, 0, 0.20);
     --strip-cross: rgba(0, 0, 0, 0.18);
@@ -60,6 +52,18 @@ html, body {
   font-size: 100%;
   font-family: "IBM Plex Sans", sans-serif;
   background-color: var(--bg, #fafafb);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 h1, h2 {
@@ -346,9 +350,6 @@ h2 {
   border-top: 0.5px solid var(--border);
   margin: 0 0 0;
 }
-.home-work--secondary-list {
-  margin-top: 36px;
-}
 .home-work__list {
   list-style: none;
   margin: 0;
@@ -377,14 +378,12 @@ h2 {
 .work-item:hover .work-item__title {
   color: var(--text-primary) !important;
 }
-.work-item:hover .work-item__dot {
-  background: var(--accent) !important;
-}
 .work-item:hover .work-item__year {
   color: var(--text-muted) !important;
 }
 .work-item a {
-  display: flex;
+  display: grid;
+  grid-template-columns: 320px 110px 1fr;
   align-items: center;
   gap: 14px;
   padding: 18px 0;
@@ -393,16 +392,26 @@ h2 {
 }
 @media (max-width: 768px) {
   .work-item a {
+    display: flex;
     gap: 10px;
     padding: 12px 0;
   }
 }
+.work-item__title-group {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-width: 0;
+}
 .work-item__dot {
+  position: relative;
   width: 5px;
   height: 5px;
+  border-radius: 50%;
   flex-shrink: 0;
   display: block;
-  transition: background 0.2s;
+  background: transparent;
 }
 @media (max-width: 768px) {
   .work-item__dot {
@@ -414,51 +423,67 @@ h2 {
   font-size: 20px;
   font-weight: 400;
   font-family: "Chakra Petch", sans-serif;
+  color: var(--work-title);
   transition: color 0.15s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 @media (max-width: 768px) {
   .work-item__title {
     font-size: 16px;
+    white-space: normal;
   }
 }
 .work-item__company {
   font-size: 13px;
   font-family: "IBM Plex Mono", monospace;
+  color: var(--work-company);
   margin-left: 2px;
   transition: color 0.15s;
 }
 .work-item__year {
   font-size: 13px;
   font-family: "IBM Plex Mono", monospace;
+  color: var(--work-year);
   margin-left: auto;
   flex-shrink: 0;
   transition: color 0.15s;
 }
-.work-item--featured .work-item__dot {
-  background: var(--work-dot-featured);
+.work-item--starred .work-item__dot {
+  background: var(--work-dot-starred);
 }
-.work-item--featured .work-item__title {
-  color: var(--work-title-featured);
+.work-item--starred .work-item__dot::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 1px solid var(--work-dot-starred);
+  transform: translate(-50%, -50%) scale(1);
+  animation: work-dot-pulse 3s ease-out infinite;
+  pointer-events: none;
 }
-.work-item--featured .work-item__company {
-  color: var(--work-company-featured);
-}
-.work-item--featured .work-item__year {
-  color: var(--work-year-featured);
-}
-.work-item--secondary .work-item__dot {
-  background: var(--work-dot-secondary);
-}
-.work-item--secondary .work-item__title {
-  color: var(--work-title-secondary);
-}
-.work-item--secondary .work-item__company {
-  color: var(--work-company-secondary);
-}
-.work-item--secondary .work-item__year {
-  color: var(--work-year-secondary);
+@media (prefers-reduced-motion: reduce) {
+  .work-item--starred .work-item__dot::after {
+    animation: none;
+    opacity: 0;
+  }
 }
 
+@keyframes work-dot-pulse {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.55;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.4);
+    opacity: 0;
+  }
+}
 .home-other-work {
   margin-top: 36px;
 }
@@ -526,7 +551,7 @@ h2 {
   display: block;
   font-size: 20px;
   font-weight: 500;
-  color: var(--work-title-featured);
+  color: var(--work-title);
   margin-bottom: 8px;
 }
 @media (max-width: 768px) {

--- a/work/cloudflare-appsec-overview.html
+++ b/work/cloudflare-appsec-overview.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600&family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;1,300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style/main.css">
-    <title>Steven Raden - AppSec Overview</title>
+    <title>Steven Raden - Application Security Overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
 <body class="project">
@@ -44,7 +44,7 @@
             </nav>
 
 <div class="section">
-    <h1 class="section--title project--title">AppSec Overview</h1>
+    <h1 class="section--title project--title">Application Security Overview</h1>
     <div class="section--content">
             <p>
         Cloudflare has a suite of application security products including WAF, Bot Management, API Shield, DDoS Protection, and more. Each lived in its own corner of the dashboard. Customers had no shared starting point. Nowhere to land, see their security posture, and understand what actually needed their attention.

--- a/work/vuln-scanner-9f3de1.html
+++ b/work/vuln-scanner-9f3de1.html
@@ -170,7 +170,7 @@
         <div class="step-badge">4</div>
         <div class="step-content">
             <h3>Review results</h3>
-            <p>Results appear at two levels: high-level discoveries (patterns across endpoints) and per-step test detail (exact requests, credentials used, expected vs. received response codes). Completed scan findings are also routed to the <a href="./cloudflare-appsec-overview.html">AppSec Overview</a> as Security Posture action items, putting them at the customer&rsquo;s AppSec entry point rather than requiring navigation to a separate tool.</p>
+            <p>Results appear at two levels: high-level discoveries (patterns across endpoints) and per-step test detail (exact requests, credentials used, expected vs. received response codes). Completed scan findings are also routed to the <a href="./cloudflare-appsec-overview.html">Application Security Overview</a> as Security Posture action items, putting them at the customer&rsquo;s AppSec entry point rather than requiring navigation to a separate tool.</p>
         </div>
     </div>
     <div class="flow-connector">


### PR DESCRIPTION
Fixes the two P1s from the design critique:
- Real <h2>/<h3> headings on the homepage (Work, Other Cloudflare Work and its two link groups, Recognition, Kind Words) instead of styled <p> tags — previously the entire page had exactly one heading element, invisible to screen-reader heading navigation.
- Collapses "Favorites" and "Selected Work" (which fully duplicated each other) into one chronological "Work" list, sorted by recency.

Replaces the old featured/secondary opacity tiers with a single starred marker: standout projects get a solid, slowly-pulsing dot (prefers-reduced- motion aware); everything else renders at the same weight with a transparent placeholder dot so titles still line up in a column. The `work-item--starred` class can be applied by hand to any row without touching the macro. Also adds a `sr-only` utility so the distinction isn't sight-only.

Lays the row out with CSS Grid on desktop (title+dot | company | year) so company aligns in a fixed column across every row regardless of title length, with an ellipsis fallback if a future title outgrows the column. The dot sits a fixed 16px from the title text itself (via a title+dot wrapper that fills the grid column) rather than floating at the column's edge. Mobile keeps the original flex-packed row.

Also renames "AppSec Overview" to "Application Security Overview" everywhere it's a title, heading, or cross-reference link, and fixes README/CLAUDE.md docs left stale by an earlier session (section() macro's actual h1/h2 output, the removed _work-card.njk component).